### PR TITLE
ci: Update default Vale version

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       version:
         description: "The version of the Vale to use"
-        default: "3.6.0"
+        default: "3.7.1"
         type: string
         required: false
 


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR updates the Vale version to `3.7.1`

