### PR TITLE
docs: unhyphenate open source

### DIFF
--- a/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/reject.txt
+++ b/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/reject.txt
@@ -19,3 +19,4 @@ Readme
 OpenShit
 Palette Extended Kubernetes
 local UI
+open-source

--- a/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/open-source.yml
+++ b/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/open-source.yml
@@ -1,0 +1,7 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+level: error
+ignorecase: true
+swap:
+  open-source: "open source"
+  Open-source: "Open source"

--- a/packages/spectrocloud-docs-internal/tests/open-source/.vale.ini
+++ b/packages/spectrocloud-docs-internal/tests/open-source/.vale.ini
@@ -1,0 +1,4 @@
+StylesPath = ../../styles/
+MinAlertLevel = suggestion
+[*.md]
+spectrocloud-docs-internal.open-source = YES

--- a/packages/spectrocloud-docs-internal/tests/open-source/fail.md
+++ b/packages/spectrocloud-docs-internal/tests/open-source/fail.md
@@ -1,0 +1,3 @@
+## Open-Source Licenses
+
+This section documents the open-source licenses associated with the libraries and modules in use by Palette and Palette eXtended Kubernetes (PXK). If you have any questions or concerns, contact us at support@spectrocloud.com.

--- a/packages/spectrocloud-docs-internal/tests/open-source/pass.md
+++ b/packages/spectrocloud-docs-internal/tests/open-source/pass.md
@@ -1,0 +1,3 @@
+## Open Source Licenses
+
+This section documents the open source licenses associated with the libraries and modules in use by Palette and Palette eXtended Kubernetes (PXK). If you have any questions or concerns, contact us at support@spectrocloud.com.


### PR DESCRIPTION
## Describe the Change

This PR adds a rule to un-hyphenate open source. 

## Jira Tickets

🎫 [DOC-1413](https://spectrocloud.atlassian.net/issues/DOC-1413?filter=11900)


[DOC-1413]: https://spectrocloud.atlassian.net/browse/DOC-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ