### PR TITLE
docs: add new numbers rule DOC-1107

### DIFF
--- a/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/numbers.yml
+++ b/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/numbers.yml
@@ -1,0 +1,17 @@
+# Copyright (c) Spectro Cloud
+# SPDX-License-Identifier: Apache-2.0
+
+extends: existence
+message: "Spell out numbers zero through nine. You mentioned '%s'."
+link: "https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Numbers"
+ignorecase: true
+level: error
+nonword: false
+scope: text
+tokens:
+  - '\b([0-9]/[0-9])\b'
+  - '\b([0-9])\b'
+  - '\b(1st)\b'
+  - '\b(2nd)\b'
+  - '\b(3rd)\b'
+  - '\b([0-9]th)\b'

--- a/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/numbers.yml
+++ b/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/numbers.yml
@@ -10,7 +10,7 @@ nonword: false
 scope: text
 tokens:
   - '\b([0-9]/[0-9])\b'
-  - '\b([0-9])\b'
+  - '(?<!\b(?:January|February|March|April|May|June|July|August|September|October|November|December)\s)\b\[0-9]\b'  
   - '\b(1st)\b'
   - '\b(2nd)\b'
   - '\b(3rd)\b'

--- a/packages/spectrocloud-docs-internal/tests/numbers/.vale.ini
+++ b/packages/spectrocloud-docs-internal/tests/numbers/.vale.ini
@@ -1,4 +1,4 @@
 StylesPath = ../../styles/
 MinAlertLevel = suggestion
 [*.md]
-spectrocloud.numbers = YES
+spectrocloud-docs-internal.numbers = YES

--- a/packages/spectrocloud-docs-internal/tests/numbers/.vale.ini
+++ b/packages/spectrocloud-docs-internal/tests/numbers/.vale.ini
@@ -1,0 +1,4 @@
+StylesPath = ../../styles/
+MinAlertLevel = suggestion
+[*.md]
+spectrocloud.numbers = YES

--- a/packages/spectrocloud-docs-internal/tests/numbers/fail.md
+++ b/packages/spectrocloud-docs-internal/tests/numbers/fail.md
@@ -1,0 +1,13 @@
+## Backup Scheduling Options
+
+Both the cluster and workspace backup support the following scheduling options:
+
+- Customize your backup for the exact month, day, hour, and minute of the user's choice.
+- Every week on Sunday at midnight.
+- Every 2 weeks at midnight.
+- Every month on the 1st at midnight.
+- Every two months on the 2nd at midnight.
+- Every two months on the 3rd at midnight.
+- Every two months on the 4th at midnight.
+- On the 0 minute of the hour.
+- Every 1/2 hour.

--- a/packages/spectrocloud-docs-internal/tests/numbers/pass.md
+++ b/packages/spectrocloud-docs-internal/tests/numbers/pass.md
@@ -1,0 +1,20 @@
+## Create Infrastructure Profile
+
+1. Log in to [Palette](https://console.spectrocloud.com/).
+
+2. From the left **Main Menu** click **Profiles**.
+
+3. Click on the **Add Cluster Profile** button.
+
+4. Fill out the following input values and ensure you select **Infrastructure** for the type. Click on **Next** to
+   continue.
+
+   | **Field**       | **Description**                                                                                                                                                                                                   |
+   | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Name**        | A custom name for the profile.                                                                                                                                                                                    |
+   | **Version**     | You only need to specify a version if you create multiple versions of a profile using the same profile name. Default: `1.0.0`.                                                                                    |
+   | **Description** | Use the description to provide context about the profile.                                                                                                                                                         |
+   | **Type**        | **Infrastructure**                                                                                                                                                                                                |
+   | **Tags**        | Assign any desired profile tags. Tags propagate to the Virtual Machines (VMs) deployed in the cloud or data center environment when clusters are created from this cluster profile. Example: `owner` or `region`. |
+
+5. You should have 10 layers in your profile. 

--- a/packages/spectrocloud-docs-internal/tests/numbers/pass.md
+++ b/packages/spectrocloud-docs-internal/tests/numbers/pass.md
@@ -18,3 +18,5 @@
    | **Tags**        | Assign any desired profile tags. Tags propagate to the Virtual Machines (VMs) deployed in the cloud or data center environment when clusters are created from this cluster profile. Example: `owner` or `region`. |
 
 5. You should have 10 layers in your profile. 
+
+6. It is currently November 3, 2024.

--- a/packages/spectrocloud/styles/spectrocloud/numbers.yml
+++ b/packages/spectrocloud/styles/spectrocloud/numbers.yml
@@ -1,0 +1,17 @@
+# Copyright (c) Spectro Cloud
+# SPDX-License-Identifier: Apache-2.0
+
+extends: existence
+message: "Spell out numbers zero through nine. You mentioned '%s'."
+link: "https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectro+Cloud+Internal+Style+Guide#Numbers"
+ignorecase: true
+level: error
+nonword: false
+scope: sentence
+tokens:
+  - '\b([0-9]/[0-9])\b'
+  - '\b([0-9])\b'
+  - '\b(1st)\b'
+  - '\b(2nd)\b'
+  - '\b(3rd)\b'
+  - '\b([0-9]th)\b'

--- a/packages/spectrocloud/styles/spectrocloud/numbers.yml
+++ b/packages/spectrocloud/styles/spectrocloud/numbers.yml
@@ -7,7 +7,7 @@ link: "https://spectrocloud.atlassian.net/wiki/spaces/DE/pages/1765933057/Spectr
 ignorecase: true
 level: error
 nonword: false
-scope: sentence
+scope: text
 tokens:
   - '\b([0-9]/[0-9])\b'
   - '\b([0-9])\b'

--- a/packages/spectrocloud/styles/spectrocloud/numbers.yml
+++ b/packages/spectrocloud/styles/spectrocloud/numbers.yml
@@ -10,7 +10,7 @@ nonword: false
 scope: text
 tokens:
   - '\b([0-9]/[0-9])\b'
-  - '\b([0-9])\b'
+  - '(?<!\b(?:January|February|March|April|May|June|July|August|September|October|November|December)\s)\b\[0-9]\b'  
   - '\b(1st)\b'
   - '\b(2nd)\b'
   - '\b(3rd)\b'

--- a/packages/spectrocloud/tests/numbers/.vale.ini
+++ b/packages/spectrocloud/tests/numbers/.vale.ini
@@ -1,0 +1,4 @@
+StylesPath = ../../styles/
+MinAlertLevel = suggestion
+[*.md]
+spectrocloud.numbers = YES

--- a/packages/spectrocloud/tests/numbers/fail.md
+++ b/packages/spectrocloud/tests/numbers/fail.md
@@ -1,0 +1,13 @@
+## Backup Scheduling Options
+
+Both the cluster and workspace backup support the following scheduling options:
+
+- Customize your backup for the exact month, day, hour, and minute of the user's choice.
+- Every week on Sunday at midnight.
+- Every 2 weeks at midnight.
+- Every month on the 1st at midnight.
+- Every two months on the 2nd at midnight.
+- Every two months on the 3rd at midnight.
+- Every two months on the 4th at midnight.
+- On the 0 minute of the hour.
+- Every 1/2 hour.

--- a/packages/spectrocloud/tests/numbers/pass.md
+++ b/packages/spectrocloud/tests/numbers/pass.md
@@ -1,0 +1,20 @@
+## Create Infrastructure Profile
+
+1. Log in to [Palette](https://console.spectrocloud.com/).
+
+2. From the left **Main Menu** click **Profiles**.
+
+3. Click on the **Add Cluster Profile** button.
+
+4. Fill out the following input values and ensure you select **Infrastructure** for the type. Click on **Next** to
+   continue.
+
+   | **Field**       | **Description**                                                                                                                                                                                                   |
+   | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Name**        | A custom name for the profile.                                                                                                                                                                                    |
+   | **Version**     | You only need to specify a version if you create multiple versions of a profile using the same profile name. Default: `1.0.0`.                                                                                    |
+   | **Description** | Use the description to provide context about the profile.                                                                                                                                                         |
+   | **Type**        | **Infrastructure**                                                                                                                                                                                                |
+   | **Tags**        | Assign any desired profile tags. Tags propagate to the Virtual Machines (VMs) deployed in the cloud or data center environment when clusters are created from this cluster profile. Example: `owner` or `region`. |
+
+5. You should have 10 layers in your profile. 

--- a/packages/spectrocloud/tests/numbers/pass.md
+++ b/packages/spectrocloud/tests/numbers/pass.md
@@ -17,4 +17,6 @@
    | **Type**        | **Infrastructure**                                                                                                                                                                                                |
    | **Tags**        | Assign any desired profile tags. Tags propagate to the Virtual Machines (VMs) deployed in the cloud or data center environment when clusters are created from this cluster profile. Example: `owner` or `region`. |
 
-5. You should have 10 layers in your profile. 
+5. You should have 10 layers in your profile.
+
+6. It is currently November 3, 2024.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds a new rule that enforces all numbers zero through nine be spelled out. This rule is added in the spectrocloud scope. 

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [DOC-1107](https://spectrocloud.atlassian.net/browse/DOC-1107)


[DOC-1107]: https://spectrocloud.atlassian.net/browse/DOC-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ