### PR TITLE
fix: add Execute to accepted words list (uppercase)

### DIFF
--- a/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -13,7 +13,7 @@ hotfixes
 is
 (?i)Cloud
 simple
-execute
+[Ee]xecute
 CLI
 reject
 [Dd]isable

--- a/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -13,7 +13,7 @@ hotfixes
 is
 (?i)Cloud
 simple
-execute
+[Ee]xecute
 CLI
 reject
 [Dd]isable


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds "Execute" to the accepted word list. Previously, only "execute" was allowed.
