### PR TITLE
fix: add Crypto to accepted words

### DIFF
--- a/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -58,6 +58,7 @@ cron
 CronJob
 CronJobs
 Crossplane
+Crypto
 CSIs
 [Cc]utover
 CVEs

--- a/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -58,6 +58,7 @@ cron
 CronJob
 CronJobs
 Crossplane
+Crypto
 CSIs
 [Cc]utover
 CVEs


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds Crypto to the accepted words as "Key Vault Crypto Service Encryption User" is a built-in Azure role.
