### PR TITLE
fix: Add Pluggable Authentication Modules to Vale

### DIFF
--- a/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -251,7 +251,7 @@ passthrough
 PCGs
 PCIe
 pfSense
-Pluggable Authentication Module
+Pluggable Authentication Modules
 Podman
 Portworx
 Postgres

--- a/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -251,6 +251,7 @@ passthrough
 PCGs
 PCIe
 pfSense
+Pluggable Authentication Module
 Podman
 Portworx
 Postgres

--- a/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -251,7 +251,7 @@ passthrough
 PCGs
 PCIe
 pfSense
-Pluggable Authentication Module
+Pluggable Authentication Modules
 Podman
 Portworx
 Postgres

--- a/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -251,6 +251,7 @@ passthrough
 PCGs
 PCIe
 pfSense
+Pluggable Authentication Module
 Podman
 Portworx
 Postgres


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR adds Pluggable Authentication Module to Vale. Spelling proof: https://github.com/linux-pam/linux-pam (see the screenshot below).
<img width="1262" height="689" alt="CleanShot 2026-04-20 at 09 09 31" src="https://github.com/user-attachments/assets/e57e5799-1ea1-46ae-93be-6d0f9ae1ec98" />


## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PE-8484](https://spectrocloud.atlassian.net/browse/PE-8484)


[PE-8484]: https://spectrocloud.atlassian.net/browse/PE-8484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ