### PR TITLE
fix: Fix PAM term

### DIFF
--- a/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -251,7 +251,7 @@ passthrough
 PCGs
 PCIe
 pfSense
-Pluggable
+[Pp]luggable
 Podman
 Portworx
 Postgres

--- a/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -251,7 +251,7 @@ passthrough
 PCGs
 PCIe
 pfSense
-Pluggable Authentication Modules
+Pluggable
 Podman
 Portworx
 Postgres

--- a/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -251,7 +251,7 @@ passthrough
 PCGs
 PCIe
 pfSense
-Pluggable
+[Pp]luggable
 Podman
 Portworx
 Postgres

--- a/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -251,7 +251,7 @@ passthrough
 PCGs
 PCIe
 pfSense
-Pluggable Authentication Modules
+Pluggable
 Podman
 Portworx
 Postgres


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the PAM term to pass Vale validation. Previously, I added "Pluggable Authentication Modules" to Vale, but "Pluggable" still gets flagged.

## Jira Tickets

<!-- Add a link to the JIRA tickets (if applicable) -->

🎫 [PE-8484](https://spectrocloud.atlassian.net/browse/PE-8484)


[PE-8484]: https://spectrocloud.atlassian.net/browse/PE-8484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ