### PR TITLE
fix: Millicpu spelling fix

### DIFF
--- a/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud-docs-internal/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -195,7 +195,7 @@ Metadata Syncer
 [Mm]ibibyte
 [Mm]iddleware
 [Mm]illicore
-[Mn]illicpu
+[Mm]illicpu
 MinIO
 [Mm]isconfiguration
 [Mm]isconfigurations

--- a/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
+++ b/packages/spectrocloud/styles/config/vocabularies/spectrocloud-vocab/accept.txt
@@ -195,7 +195,7 @@ Metadata Syncer
 [Mm]ibibyte
 [Mm]iddleware
 [Mm]illicore
-[Mn]illicpu
+[Mm]illicpu
 MinIO
 [Mm]isconfiguration
 [Mm]isconfigurations


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR fixes the spelling of Millicpu.
