### PR TITLE
fix: Various fixes related to CAPI Override PR

### DIFF
--- a/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/acronym.yml
+++ b/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/acronym.yml
@@ -21,9 +21,12 @@ scope: text
 # Match two to five capital letters surrounded by brackets to detect an acronym definition.
 first: "[(][A-Z]{2,5}[)]"
 
-# Match two to five capitalised words separated by any number of dashes
-# or whitespaces before the acronym definition.
-second: '(\b(([A-Z][a-z]+)[\-\s ]{1,}){2,5})([(][A-Z]{2,5}[)])'
+# Match two to five capitalized words separated by any number of dashes or whitespaces
+# before the acronym definition. Each word only needs to start with an uppercase letter, so
+# all-uppercase acronyms (for example "API" or "AWS") and CamelCase product names (for
+# example "CloudStack") that appear inside a definition are accepted. The leading uppercase
+# requirement still flags lowercase definitions such as "cluster api provider aws (CAPA)".
+second: '(\b(([A-Z][A-Za-z]+)[\-\s ]{1,}){2,5})([(][A-Z]{2,5}[)])'
 
 # Acronyms listed in the exceptions are ignored entirely by this rule. This prevents false positives when an acronym
 # appears in parentheses without a formal title-cased definition before it (for example, "Use the Palette endpoint (API)").

--- a/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/inclusive.yml
+++ b/packages/spectrocloud-docs-internal/styles/spectrocloud-docs-internal/inclusive.yml
@@ -9,5 +9,7 @@ level: error
 nonword: true
 scope: raw
 tokens:
-  - '\b(master)\b(?! branch)'
+  # The negative lookbehind on '/' skips 'master' when it is part of a URL or file path
+  # (for example, '.../blob/master/...') while still flagging it in prose such as 'master node'.
+  - '(?<!/)\b(master)\b(?! branch)'
   - '\bslave\b'

--- a/packages/spectrocloud-docs-internal/tests/acronym/pass.md
+++ b/packages/spectrocloud-docs-internal/tests/acronym/pass.md
@@ -13,3 +13,5 @@ Use the following steps to resolve the Virtual Private Cloud (VPC) error.
    :::
 
 The kubeconfig authenticates you through OpenID Connect (OIDC) as a specific user.
+
+Palette supports Cluster API Provider AWS (CAPA) and Cluster API Provider CloudStack (CAPC).

--- a/packages/spectrocloud-docs-internal/tests/inclusive/pass.md
+++ b/packages/spectrocloud-docs-internal/tests/inclusive/pass.md
@@ -1,3 +1,5 @@
 # Cluster Nodes
 
 The source code can be found in the master branch of the public repository.
+
+See https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md for more information.

--- a/packages/spectrocloud/styles/spectrocloud/acronym.yml
+++ b/packages/spectrocloud/styles/spectrocloud/acronym.yml
@@ -21,9 +21,12 @@ scope: text
 # Match two to five capital letters surrounded by brackets to detect an acronym definition.
 first: "[(][A-Z]{2,5}[)]"
 
-# Match two to five capitalised words separated by any number of dashes
-# or whitespaces before the acronym definition.
-second: '(\b(([A-Z][a-z]+)[\-\s ]{1,}){2,5})([(][A-Z]{2,5}[)])'
+# Match two to five capitalized words separated by any number of dashes or whitespaces
+# before the acronym definition. Each word only needs to start with an uppercase letter, so
+# all-uppercase acronyms (for example "API" or "AWS") and CamelCase product names (for
+# example "CloudStack") that appear inside a definition are accepted. The leading uppercase
+# requirement still flags lowercase definitions such as "cluster api provider aws (CAPA)".
+second: '(\b(([A-Z][A-Za-z]+)[\-\s ]{1,}){2,5})([(][A-Z]{2,5}[)])'
 
 # Acronyms listed in the exceptions are ignored entirely by this rule. This prevents false positives when an acronym
 # appears in parentheses without a formal title-cased definition before it (for example, "Use the Palette endpoint (API)").

--- a/packages/spectrocloud/styles/spectrocloud/inclusive.yml
+++ b/packages/spectrocloud/styles/spectrocloud/inclusive.yml
@@ -9,5 +9,7 @@ level: error
 nonword: true
 scope: raw
 tokens:
-  - '\b(master)\b(?! branch)'
+  # The negative lookbehind on '/' skips 'master' when it is part of a URL or file path
+  # (for example, '.../blob/master/...') while still flagging it in prose such as 'master node'.
+  - '(?<!/)\b(master)\b(?! branch)'
   - '\bslave\b'

--- a/packages/spectrocloud/tests/acronym/pass.md
+++ b/packages/spectrocloud/tests/acronym/pass.md
@@ -13,3 +13,5 @@ Use the following steps to resolve the Virtual Private Cloud (VPC) error.
    :::
 
 The kubeconfig authenticates you through OpenID Connect (OIDC) as a specific user.
+
+Palette supports Cluster API Provider AWS (CAPA) and Cluster API Provider CloudStack (CAPC).

--- a/packages/spectrocloud/tests/inclusive/pass.md
+++ b/packages/spectrocloud/tests/inclusive/pass.md
@@ -1,3 +1,5 @@
 # Cluster Nodes
 
 The source code can be found in the master branch of the public repository.
+
+See https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md for more information.


### PR DESCRIPTION
## Describe the Change

<!-- Add a description of what the pull request is changing, adding, and any other relevant context.  -->

This PR addresses the following issues:

- CAPA / CAPC false positives - Previously, every word before the acronym was to be in strict Title Case (`[A-Z][a-z]+`). So a word like **AWS** (all caps) or **CloudStack** (CamelCase) immediately before **CAPA**/**CAPC** broke the match, and the acronym was flagged as undefined. Broadened the per-word pattern so each word only needs to start with an uppercase letter.
- Kubelet can now be spelled in lowercase.
- `master` will no longer be flagged if it is present in a URL.
